### PR TITLE
[BUGFIX] Causes autoload to break if not in WP

### DIFF
--- a/src/load.php
+++ b/src/load.php
@@ -13,7 +13,7 @@ use WPEmerge\Support\AliasLoader;
 use Pimple\Container;
 
 if ( php_sapi_name() !== 'cli' && ! defined( 'ABSPATH' ) ) {
-	exit;
+	return;
 }
 
 // @codeCoverageIgnoreStart


### PR DESCRIPTION
Hi,
I include wpemerge as a project wide depency.
I need to call some scripts that requires the `autoload.php` but are not in the context of WordPress.
Calling  `exit` makes the autoload to stop the `php` process and break the request.

## Discussion

_Please submit a separate issue for discussion before submitting a PR._

_PRs without a discussion issue will be closed._

Issue: #xyz

## What this PR does

_Please add a description of what the PR does._
