### PR TITLE
Allow johnpbloch/wordpress-core-installer to run

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,6 +3,7 @@ build:
     analysis:
       dependencies:
         before:
+          - composer config --no-plugins allow-plugins.johnpbloch/wordpress-core-installer true
           - composer require --dev johnpbloch/wordpress
       project_setup:
         override: true


### PR DESCRIPTION
## What this PR does

Scrutinizer uses Composer v2 and fails without this PR.
